### PR TITLE
Switch from bundle to bundler in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 gem 'rspec'
 gem 'rake'
-gem 'bundle'
+gem 'bundler'
 gem 'yard'
 gem 'ansi'
 #gem 'rubyzip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ GEM
   remote: http://rubygems.org/
   specs:
     ansi (1.5.0)
-    bundle (0.0.1)
-      bundler
     diff-lcs (1.2.5)
     github-markup (1.4.0)
     rake (10.4.2)
@@ -29,7 +27,7 @@ PLATFORMS
 
 DEPENDENCIES
   ansi
-  bundle
+  bundler
   github-markup
   rake
   redcarpet


### PR DESCRIPTION
Whilst working on [Libraries.io](https://libraries.io) I noticed that this project depends on the [`bundle`](https://github.com/will/bundle) gem rather than [`bundler`](https://github.com/bundler/bundler/), this pull request fixes the typo and updates the Gemfile.lock